### PR TITLE
Generate uuids so that editorial don't have to do that in the spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Output examples for authors and roles JSON from Berta are provided below.
     "imageurl": "http//image.site.com/Martin_Wolf.png",
     "biography": "<p>Martin Wolf is chief economics commentator at the Financial Times, London. He was awarded the CBE (Commander of the British Empire) in 2000 “for services to financial journalism”.</p>",
     "twitterhandle": "@martinwolf_",
-    "uuid": "daf5fed2-013c-468d-85c4-aee779b8aa54",
     "tmeidentifier": "Q0ItMDAwMDkwMA==-QXV0aG9ycw==",
-    "membershipuuid": "03ca31b5-534a-4d26-bd09-3532b04640d5"
   },
   {
     "name": "Lucy Kellaway",
@@ -31,9 +29,7 @@ Output examples for authors and roles JSON from Berta are provided below.
     "imageurl": "http//image.site.com/Lucy_Kellaway.png",
     "biography": "<p>Lucy Kellaway is an Associate Editor and management columnist of the FT. For the past 15 years her weekly Monday column has poked fun at management fads and jargon and celebrated the ups and downs of office life.</p>",
     "twitterhandle": null,
-    "uuid": "daf5fed2-013c-468d-85c4-aee779b8aa55",
     "tmeidentifier": "Q0ItMDAwMDkyNg==-QXV0aG9ycw==",
-    "membershipuuid": "7318d8eb-5d48-4008-8744-aa3f18957216"
   },
   ...
 ]  
@@ -55,7 +51,7 @@ Output examples for authors and roles JSON from Berta are provided below.
 
 # How to run
 
-## Locally: 
+## Locally:
 
 `go get github.com/Financial-Times/curated-authors-memberships-transformer`
 
@@ -78,7 +74,7 @@ $GOPATH/bin/curated-authors-memberships-transformer
 
 ##Refresh Cache
 `POST /transformers/memberships` with empty request message refreshes the transformer cache.
-The transformer loads Bertha data in memory at startup time by default. Every time a POST triggers this endpoint, the transformer refetches Bertha data. 
+The transformer loads Bertha data in memory at startup time by default. Every time a POST triggers this endpoint, the transformer refetches Bertha data.
 
 ##Count
 `GET /transformers/memberships/__count` returns the number of available memberships to be transformed as plain text.
@@ -89,28 +85,28 @@ A response example is provided below.
 ```
 
 ##IDs
-`GET /transformers/memberships/__ids` returns the list of membership's UUIDs available to be transformed. 
+`GET /transformers/memberships/__ids` returns the list of membership's UUIDs available to be transformed.
 The output is a sequence of JSON objects, however the returned `Content-Type` header is `text\plain`.
 This output data will be consumed as a stream by the [concept publisher](https://github.com/Financial-Times/concept-publisher).
 A response example is provided below.
 
 ```
-{"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd2"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd5"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd9"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd8"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd0"} {"id":"daf5fed2-013c-468d-85c4-aee779b8aa53"} {"id":"daf5fed2-013c-468d-85c4-aee779b8aa51"} 
+{"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd2"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd5"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd9"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd8"} {"id":"5baaf5a4-2d9f-11e6-a100-1316a778acd0"} {"id":"daf5fed2-013c-468d-85c4-aee779b8aa53"} {"id":"daf5fed2-013c-468d-85c4-aee779b8aa51"}
 ```
 
 ##Membership by UUID
-`GET /transformers/memberships/{uuid}` returns author membership data of the given membership uuid. 
+`GET /transformers/memberships/{uuid}` returns author membership data of the given membership uuid.
 A response example is provided below.
 
 ```
 {
-  "uuid": "e6e8b0e4-4833-11e6-beb8-9e71128cae77",
+  "uuid": "78a23be4-b7b0-392a-a900-582a0dbe383b",
   "prefLabel": "Chief Economics Commentator",
-  "personUuid": "6f53299a-799d-49ae-ae9d-7e1f298daef7",
+  "personUuid": "0f07d468-fc37-3c44-bf19-a81f2aae9f36",
   "organisationUuid": "dac01f07-4b6d-3615-8532-a56752cc7e5f",
   "alternativeIdentifiers": {
     "uuids": [
-      "e6e8b0e4-4833-11e6-beb8-9e71128cae77"
+      "78a23be4-b7b0-392a-a900-582a0dbe383b"
     ]
   },
   "membershipRoles": [
@@ -120,4 +116,3 @@ A response example is provided below.
   ]
 }
 ```
-

--- a/app.go
+++ b/app.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
 	"github.com/Financial-Times/go-fthealth/v1a"
 	"github.com/Financial-Times/http-handlers-go/httphandlers"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
@@ -9,9 +13,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
 	"github.com/rcrowley/go-metrics"
-	"net/http"
-	_ "net/http/pprof"
-	"os"
 )
 
 func main() {

--- a/author.go
+++ b/author.go
@@ -2,8 +2,7 @@ package main
 
 // This struct reflects the JSON data model of curated authors from Bertha
 type author struct {
-	UUID           string `json:"uuid"`
-	Role           string `json:"role"`
-	Jobtitle       string `json:"jobtitle"`
-	Membershipuuid string `json:"membershipuuid"`
+	Role          string `json:"role"`
+	Jobtitle      string `json:"jobtitle"`
+	TmeIdentifier string `json:"tmeidentifier"`
 }

--- a/bertha_role.go
+++ b/bertha_role.go
@@ -3,5 +3,5 @@ package main
 type berthaRole struct {
 	UUID       string `json:"uuid"`
 	Preflabel  string `json:"preflabel"`
-	ParentUuid string `json:"parentUuid,omitempty"`
+	ParentUUID string `json:"parentUuid,omitempty"`
 }

--- a/bertha_service_test.go
+++ b/bertha_service_test.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 )
 
 const etag = "W/\"75e-78600296\""
@@ -18,15 +19,15 @@ const authorsBerthaOutput = "test-resources/bertha-authors-output.json"
 const rolesBerthaOutput = "test-resources/bertha-roles-output.json"
 
 var membership1 = membership{
-	UUID:                   "e6e8b382-4833-11e6-beb8-9e71128cae77",
+	UUID:                   expectedMembershipUUID,
 	PrefLabel:              "Chief Economics Commentator",
-	PersonUUID:             "daf5fed2-013c-468d-85c4-aee779b8aa53",
-	OrganisationUUID:       "dac01f07-4b6d-3615-8532-a56752cc7e5f",
-	AlternativeIdentifiers: alternativeIdentifiers{UUIDS: []string{"e6e8b382-4833-11e6-beb8-9e71128cae77"}},
+	PersonUUID:             expectedAuthorUUID,
+	OrganisationUUID:       ftUUID,
+	AlternativeIdentifiers: alternativeIdentifiers{UUIDS: []string{expectedMembershipUUID}},
 	MembershipRoles:        []membershipRole{membershipRole{RoleUUID: "7ef75a6a-b6bf-4eb7-a1da-03e0acabef1b"}},
 }
 var membership2 = membership{
-	UUID: "c721a241-9250-4c77-9620-8abb08027686",
+	UUID: "a1c08d1f-9c19-370b-af34-80aa6cf3c0ad",
 }
 
 type berthaMock struct {
@@ -105,8 +106,8 @@ func TestShouldReturnMembershipsUuids(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(uuids), "Bertha should return 2 authors")
-	assert.Equal(t, true, contains(uuids, membership1.UUID), "It should contain membership1 UUID")
-	assert.Equal(t, true, contains(uuids, membership2.UUID), "It should contain membership2 UUID")
+	assert.Equal(t, true, contains(uuids, membership1.UUID), "actual UUIDS=%s should contain expected membership1 UUID=%s", uuids, membership1.UUID)
+	assert.Equal(t, true, contains(uuids, membership2.UUID), "actual UUIDS=%s should contain expected membership2 UUID=%s", uuids, membership2.UUID)
 }
 
 func TestShouldReturnSingleMembership(t *testing.T) {

--- a/bertha_transformer_test.go
+++ b/bertha_transformer_test.go
@@ -1,65 +1,22 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-var anAuthorUuid = "1eaeabeb-01ef-42dc-bf95-459e9087a763"
-var aRoleLabel = "Superhero"
-var anotherRoleLabel = "Rockstar"
-var aJobTitle = "Avengers member"
-var aMembershipUuid = "0311bc2c-1dc1-489b-a202-59252c28d2de"
-var aRoleUuid = "b4f06685-9f58-40af-850f-07f1585fab73"
-var anotherRoleUuid = "b4f06685-9f58-40af-850f-07f1585fab73"
-var yetAnotherRoleUuid = "93e60bde-dc80-4ed3-8cc1-a19346c52014"
+//For fixtures see test_fixtures.go
 
-var anAuthor = author{
-	UUID:           anAuthorUuid,
-	Role:           aRoleLabel,
-	Jobtitle:       aJobTitle,
-	Membershipuuid: aMembershipUuid,
-}
-
-var anotherAuthor = author{
-	UUID:           "57d23eb1-65dc-4f67-ba4b-f76ca60efccc",
-	Role:           anotherRoleLabel,
-	Jobtitle:       aJobTitle,
-	Membershipuuid: aMembershipUuid,
-}
-
-var aBerthaRole = berthaRole{
-	UUID:       aRoleUuid,
-	Preflabel:  aRoleLabel,
-	ParentUuid: yetAnotherRoleUuid,
-}
-
-var anotherBerthaRole = berthaRole{
-	UUID:      yetAnotherRoleUuid,
-	Preflabel: "Hero",
-}
-
-var aNameRolesMap = map[string]berthaRole{aBerthaRole.Preflabel: aBerthaRole, anotherBerthaRole.Preflabel: anotherBerthaRole}
-var aUuidRolesMap = map[string]berthaRole{aBerthaRole.UUID: aBerthaRole, anotherBerthaRole.UUID: anotherBerthaRole}
-
-var aMembership = membership{
-	UUID:                   aMembershipUuid,
-	PrefLabel:              aJobTitle,
-	PersonUUID:             anAuthorUuid,
-	OrganisationUUID:       ftUuid,
-	AlternativeIdentifiers: alternativeIdentifiers{UUIDS: []string{aMembershipUuid}},
-	MembershipRoles:        []membershipRole{membershipRole{RoleUUID: aRoleUuid}, membershipRole{RoleUUID: yetAnotherRoleUuid}},
-}
-
-func TestShouldTransformAuthorToPersonSucessfully(t *testing.T) {
+func TestShouldTransformAuthorToPersonSuccessfully(t *testing.T) {
 	transformer := berthaTransformer{}
-	m, err := transformer.toMembership(anAuthor, aUuidRolesMap, aNameRolesMap)
+	m, err := transformer.toMembership(anAuthor, aUUIDRolesMap, aNameRolesMap)
 	assert.Nil(t, err)
-	assert.Equal(t, aMembership, m, "The membership is transformed properly")
+	assert.Equal(t, expectedMembership, m, "The membership is transformed properly")
 }
 
 func TestShouldReturnErrorWhenRoleIsNotFound(t *testing.T) {
 	transformer := berthaTransformer{}
-	_, err := transformer.toMembership(anotherAuthor, aUuidRolesMap, aNameRolesMap)
+	_, err := transformer.toMembership(anotherAuthor, aUUIDRolesMap, aNameRolesMap)
 	assert.NotNil(t, err)
 }

--- a/membership_handlers.go
+++ b/membership_handlers.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"reflect"
+
 	"github.com/Financial-Times/go-fthealth/v1a"
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
-	"net/http"
-	"reflect"
 )
 
 type membershipHandler struct {

--- a/test-resources/bertha-authors-output.json
+++ b/test-resources/bertha-authors-output.json
@@ -7,9 +7,7 @@
 		"imageurl": "https://next-geebee.ft.com/image/v1/images/raw/fthead:martin-wolf?source=next",
 		"biography": "Martin Wolf is chief economics commentator at the Financial Times, London. He was awarded the CBE (Commander of the British Empire) in 2000 “for services to financial journalism”",
 		"twitterhandle": "@martinwolf_",
-		"uuid": "daf5fed2-013c-468d-85c4-aee779b8aa53",
-		"tmeidentifier": "Q0ItMDAwMDkwMA==-QXV0aG9ycw==",
-		"membershipuuid": "e6e8b382-4833-11e6-beb8-9e71128cae77"
+		"tmeidentifier": "Q0ItMDAwMDkwMA==-QXV0aG9ycw=="
 	},
 	{
 		"name": "Lucy Kellaway",
@@ -18,8 +16,6 @@
 		"imageurl": "https://next-geebee.ft.com/image/v1/images/raw/fthead:lucy-kellaway?source=next",
 		"biography": "Lucy Kellaway is an Associate Editor and management columnist of the FT. For the past 15 years her weekly Monday column has poked fun at management fads and jargon and celebrated the ups and downs of office life.",
 		"twitterhandle": null,
-		"uuid": "daf5fed2-013c-468d-85c4-aee779b8aa51",
-		"tmeidentifier": "Q0ItMDAwMDkyNg==-QXV0aG9ycw==",
-		"membershipuuid": "c721a241-9250-4c77-9620-8abb08027686"
+		"tmeidentifier": "Q0ItMDAwMDkyNg==-QXV0aG9ycw=="
 	}
 ]

--- a/test-resources/bertha-roles-output.json
+++ b/test-resources/bertha-roles-output.json
@@ -1,1 +1,9 @@
-[{"uuid":"33ee38a4-c677-4952-a141-2ae14da3aedd","preflabel":"Journalist"},{"uuid":"7ef75a6a-b6bf-4eb7-a1da-03e0acabef1b","preflabel":"Columnist"}]
+[{
+  "uuid":"33ee38a4-c677-4952-a141-2ae14da3aedd",
+  "preflabel":"Journalist"
+  },
+  {
+    "uuid":"7ef75a6a-b6bf-4eb7-a1da-03e0acabef1b",
+    "preflabel":"Columnist"
+  }
+]

--- a/test-resources/transformed-membership-output.json
+++ b/test-resources/transformed-membership-output.json
@@ -1,1 +1,13 @@
-{"uuid":"0311bc2c-1dc1-489b-a202-59252c28d2de","prefLabel":"Avengers member","personUuid":"1eaeabeb-01ef-42dc-bf95-459e9087a763","organisationUuid":"dac01f07-4b6d-3615-8532-a56752cc7e5f","alternativeIdentifiers":{"uuids":["0311bc2c-1dc1-489b-a202-59252c28d2de"]},"membershipRoles":[{"roleUuid":"b4f06685-9f58-40af-850f-07f1585fab73"},{"roleUuid":"93e60bde-dc80-4ed3-8cc1-a19346c52014"}]}
+{
+  "uuid":"78a23be4-b7b0-392a-a900-582a0dbe383b",
+  "prefLabel":"Avengers member",
+  "personUuid":"0f07d468-fc37-3c44-bf19-a81f2aae9f36",
+  "organisationUuid":"dac01f07-4b6d-3615-8532-a56752cc7e5f",
+  "alternativeIdentifiers":{
+    "uuids":["78a23be4-b7b0-392a-a900-582a0dbe383b"]
+  },
+  "membershipRoles":[
+    {"roleUuid":"b4f06685-9f58-40af-850f-07f1585fab73"},
+    {"roleUuid":"93e60bde-dc80-4ed3-8cc1-a19346c52014"}
+  ]
+}

--- a/test_fixtures.go
+++ b/test_fixtures.go
@@ -1,0 +1,57 @@
+package main
+
+var anAuthorTmeIdentifier = "Q0ItMDAwMDkwMA==-QXV0aG9ycw=="
+
+// MD5 hash of the author TME identifier
+var expectedAuthorUUID = "0f07d468-fc37-3c44-bf19-a81f2aae9f36"
+
+// MD5 hash using both the expected author uuid and organisation uuid
+var expectedMembershipUUID = "78a23be4-b7b0-392a-a900-582a0dbe383b"
+
+var aRoleLabel = "Superhero"
+var anotherRoleLabel = "Rockstar"
+var aJobTitle = "Avengers member"
+
+var aRoleUUID = "b4f06685-9f58-40af-850f-07f1585fab73"
+var anotherRoleUUID = "b4f06685-9f58-40af-850f-07f1585fab73"
+var yetAnotherRoleUUID = "93e60bde-dc80-4ed3-8cc1-a19346c52014"
+
+var anotherAuthorTmeIdentifier = "Q0ItMDAwMDkyNg==-QXV0aG9ycw=="
+
+// MD5 hash of the anotherAuthor TME Identifier
+var expectedAnotherAuthorUUID = "8f9ac45f-2cc2-35f7-83f4-579c66a09eb0"
+
+var anAuthor = author{
+	Role:          aRoleLabel,
+	Jobtitle:      aJobTitle,
+	TmeIdentifier: anAuthorTmeIdentifier,
+}
+
+var anotherAuthor = author{
+	Role:          anotherRoleLabel,
+	Jobtitle:      aJobTitle,
+	TmeIdentifier: "",
+}
+
+var aBerthaRole = berthaRole{
+	UUID:       aRoleUUID,
+	Preflabel:  aRoleLabel,
+	ParentUUID: yetAnotherRoleUUID,
+}
+
+var anotherBerthaRole = berthaRole{
+	UUID:      yetAnotherRoleUUID,
+	Preflabel: "Hero",
+}
+
+var aNameRolesMap = map[string]berthaRole{aBerthaRole.Preflabel: aBerthaRole, anotherBerthaRole.Preflabel: anotherBerthaRole}
+var aUUIDRolesMap = map[string]berthaRole{aBerthaRole.UUID: aBerthaRole, anotherBerthaRole.UUID: anotherBerthaRole}
+
+var expectedMembership = membership{
+	UUID:                   expectedMembershipUUID,
+	PrefLabel:              aJobTitle,
+	PersonUUID:             expectedAuthorUUID,
+	OrganisationUUID:       ftUUID,
+	AlternativeIdentifiers: alternativeIdentifiers{UUIDS: []string{expectedMembershipUUID}},
+	MembershipRoles:        []membershipRole{membershipRole{RoleUUID: aRoleUUID}, membershipRole{RoleUUID: yetAnotherRoleUUID}},
+}


### PR DESCRIPTION
Generates the person uuid from an MD5 hash of the tme identifier (matching the behaviour in the curated-authors-transformer) and the membership uuid from a combo of person and org uuids