### PR TITLE
use new image service

### DIFF
--- a/test-resources/bertha-authors-output.json
+++ b/test-resources/bertha-authors-output.json
@@ -4,7 +4,7 @@
 		"role": "Columnist",
 		"jobtitle" : "Chief Economics Commentator",
 		"email": "martin.wolf@ft.com",
-		"imageurl": "https://next-geebee.ft.com/image/v1/images/raw/fthead:martin-wolf?source=next",
+		"imageurl": "https://www.ft.com/__origami/service/image/v2/images/raw/fthead:martin-wolf?source=next",
 		"biography": "Martin Wolf is chief economics commentator at the Financial Times, London. He was awarded the CBE (Commander of the British Empire) in 2000 “for services to financial journalism”",
 		"twitterhandle": "@martinwolf_",
 		"tmeidentifier": "Q0ItMDAwMDkwMA==-QXV0aG9ycw=="
@@ -13,7 +13,7 @@
 		"name": "Lucy Kellaway",
 		"role": "Columnist",
 		"email": "lucy.kellaway@ft.com",
-		"imageurl": "https://next-geebee.ft.com/image/v1/images/raw/fthead:lucy-kellaway?source=next",
+		"imageurl": "https://www.ft.com/__origami/service/image/v2/images/raw/fthead:lucy-kellaway?source=next",
 		"biography": "Lucy Kellaway is an Associate Editor and management columnist of the FT. For the past 15 years her weekly Monday column has poked fun at management fads and jargon and celebrated the ups and downs of office life.",
 		"twitterhandle": null,
 		"tmeidentifier": "Q0ItMDAwMDkyNg==-QXV0aG9ycw=="


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2